### PR TITLE
Ignore test folder in coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests/"


### PR DESCRIPTION
After merging this, at the bottom of the codecov report you should see that the `tests/` folder isn't listed.

Just returning the favor.  :)